### PR TITLE
Demo_Rand: use OSVVM library.

### DIFF
--- a/demo/Demo_Rand.vhd
+++ b/demo/Demo_Rand.vhd
@@ -98,9 +98,9 @@ library IEEE ;
   use std.textio.all ;
   use ieee.std_logic_textio.all ;
 
-library SynthWorks ; 
-  use SynthWorks.RandomBasePkg.all ; 
-  use SynthWorks.RandomPkg.all ; 
+library OSVVM ;
+  use OSVVM.RandomBasePkg.all ;
+  use OSVVM.RandomPkg.all ;
 
 use work.TestSupportPkg.all ; 
 


### PR DESCRIPTION
Demo_Rand was using library SynthWorks for OSVVM packages, instead of OSVVM.